### PR TITLE
fix #192 - offhand dupe bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,17 +13,20 @@ buildscript {
     }
 }
 
+plugins {
+	id "com.wynprice.cursemaven" version "1.1.0"
+}
+
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/base.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/ccl.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/thermal.gradle'
+apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/buildcraft.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/thaumcraft.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/baubles.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/nei.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/albedo.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/ftb.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/chisel.gradle'
-apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/mousetweaks.gradle'
-apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/itemscroller.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/itemscroller.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/buildinggadgets.gradle'
 apply from : 'https://github.com/p455w0rd/buildscripts/raw/master/enderio.gradle'

--- a/src/main/java/p455w0rd/danknull/blocks/BlockDankNullDock.java
+++ b/src/main/java/p455w0rd/danknull/blocks/BlockDankNullDock.java
@@ -129,7 +129,7 @@ public class BlockDankNullDock extends BlockContainer implements IModelHolder {
 			}
 			if (!player.isSneaking() && hand == MAIN_HAND) {
 				if (!dankDock.getDankNull().isEmpty()) {
-					ModGuiHandler.launchGui(GUIType.DANKNULL_TE, player, world, pos);
+					ModGuiHandler.launchGui(GUIType.DANKNULL_TE, player, world, pos, null);
 					return true;
 				}
 			}

--- a/src/main/java/p455w0rd/danknull/client/gui/GuiDankNull.java
+++ b/src/main/java/p455w0rd/danknull/client/gui/GuiDankNull.java
@@ -34,8 +34,7 @@ import p455w0rd.danknull.integration.Chisel;
 import p455w0rd.danknull.inventory.InventoryDankNull;
 import p455w0rd.danknull.inventory.slot.SlotDankNull;
 import p455w0rd.danknull.inventory.slot.SlotDankNullDock;
-import p455w0rd.danknull.network.PacketMouseWheel;
-import p455w0rd.danknull.network.PacketSyncDankNullDock;
+import p455w0rd.danknull.network.PacketRequestInitialUpdate;
 import p455w0rd.danknull.util.DankNullUtils;
 import p455w0rd.danknull.util.DankNullUtils.ItemExtractionMode;
 import p455w0rd.danknull.util.DankNullUtils.ItemPlacementMode;
@@ -62,12 +61,17 @@ public class GuiDankNull extends GuiModular {
 	protected int ySize = 140;
 	private final DankNullTier tier;
 
-	public GuiDankNull(final Container c, final InventoryDankNull inventory, final EntityPlayer player) {
+	public GuiDankNull(final Container c, final DankNullTier tier, final EntityPlayer player) {
 		super(c);
-		tier = DankNullUtils.getTier(inventory);
+		this.tier = tier;
 		setWidth(210);
 		setHeight(tier.getGuiHeight());
 		setBackgroundTexture(tier.getGuiBackground());
+		ModNetworking.getInstance().sendToServer(new PacketRequestInitialUpdate());
+	}
+
+	public GuiDankNull(final ContainerDankNull c, final EntityPlayer player) {
+		this(c, DankNullUtils.getTier(c.getDankNullInPlayerSlot()), player);
 	}
 
 	@Override
@@ -153,7 +157,7 @@ public class GuiDankNull extends GuiModular {
 		if (isTile()) {
 			return DankNullUtils.getNewDankNullInventory(((ContainerDankNullDock) inventorySlots).getDankNull());
 		}
-		return ((ContainerDankNull) inventorySlots).getDankNullInventory();
+		return DankNullUtils.getNewDankNullInventory(((ContainerDankNull) inventorySlots).getPlayerSlot(), mc.player);
 	}
 
 	@Override
@@ -383,7 +387,9 @@ public class GuiDankNull extends GuiModular {
 				Gui.drawRect(i, j, i + 16, j + 16, -2130706433);
 			}
 			GlStateManager.enableDepth();
-			Minecraft.getMinecraft().getRenderItem().renderItemAndEffectIntoGUI(itemstack, i, j);
+			final ItemStack tempStack = itemstack.copy();
+			tempStack.setCount(1);
+			Minecraft.getMinecraft().getRenderItem().renderItemAndEffectIntoGUI(tempStack, i, j);
 			renderItemOverlayIntoGUI(RenderUtils.getFontRenderer(), itemstack, i, j);
 		}
 		itemRender.zLevel = 0.0F;
@@ -457,7 +463,7 @@ public class GuiDankNull extends GuiModular {
 		if (!EasyMappings.player().isEntityAlive() || EasyMappings.player().isDead) {
 			EasyMappings.player().closeScreen();
 		}
-		getDankNullInventory().loadInventory(getDankNullInventory().getDNTag());
+		//getDankNullInventory().loadInventory(getDankNullInventory().getDNTag());
 	}
 
 	@Override
@@ -498,7 +504,7 @@ public class GuiDankNull extends GuiModular {
 		*/
 	}
 
-	private void mouseWheelEvent(final int x, final int y, final int wheel) {
+	/*private void mouseWheelEvent(final int x, final int y, final int wheel) {
 		final Slot slot = getSlotAtPos(x, y);
 		if (slot instanceof SlotDankNull || slot instanceof SlotDankNullDock) {
 			final ItemStack item = slot.getStack();
@@ -506,9 +512,9 @@ public class GuiDankNull extends GuiModular {
 			for (int i = 0; i < times; i++) {
 				final Slot s = inventorySlots.inventorySlots.get(36 + slot.getSlotIndex());
 				if (s instanceof SlotDankNull || s instanceof SlotDankNullDock) {
-
+	
 					if (wheel < 0) { //add
-
+	
 						final ItemStack mouseStack = mc.player.inventory.getItemStack();
 						final ItemStack slotStack = s.getStack();
 						final InventoryDankNull tmpInv = DankNullUtils.getNewDankNullInventory(getDankNull());
@@ -550,14 +556,14 @@ public class GuiDankNull extends GuiModular {
 				ModNetworking.getInstance().sendToServer(new PacketMouseWheel(wheel, slot.getSlotIndex()));
 			}
 		}
-	}
+	}*/
 
-	private boolean addStack(final InventoryDankNull inventory, final ItemStack addedStack) {
+	/*private boolean addStack(final InventoryDankNull inventory, final ItemStack addedStack) {
 		if (inventorySlots instanceof ContainerDankNullDock) {
 			return ((ContainerDankNullDock) inventorySlots).addStack(inventory, addedStack);
 		}
-		return ((ContainerDankNull) inventorySlots).addStack(addedStack);
-	}
+		return ((ContainerDankNull) inventorySlots).addStack(inventory, addedStack);
+	}*/
 
 	@Override
 	protected void mouseReleased(final int mouseX, final int mouseY, final int state) {

--- a/src/main/java/p455w0rd/danknull/client/render/RenderModel.java
+++ b/src/main/java/p455w0rd/danknull/client/render/RenderModel.java
@@ -6,14 +6,12 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.model.ModelPlayer;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.color.ItemColors;
 import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.client.model.pipeline.LightUtil;
@@ -63,9 +61,9 @@ public class RenderModel {
 
 	// =========
 
-	private static void render(final ModelPlayer model, final int color, final EntityPlayer player, final float partialTicks, final boolean multiPass) {
+	/*private static void render(final ModelPlayer model, final int color, final EntityPlayer player, final float partialTicks, final boolean multiPass) {
 		Minecraft.getMinecraft().getRenderManager().renderEntityStatic(player, partialTicks, false);
 		//rm.doRenderEntity(player, player.posX, player.posY, player.posZ, player.cameraYaw, partialTicks, multiPass);
-	}
+	}*/
 
 }

--- a/src/main/java/p455w0rd/danknull/container/ContainerDankNull.java
+++ b/src/main/java/p455w0rd/danknull/container/ContainerDankNull.java
@@ -3,9 +3,12 @@ package p455w0rd.danknull.container;
 import net.minecraft.entity.player.*;
 import net.minecraft.inventory.*;
 import net.minecraft.item.ItemStack;
+import p455w0rd.danknull.init.ModNetworking;
 import p455w0rd.danknull.inventory.InventoryDankNull;
+import p455w0rd.danknull.inventory.PlayerSlot;
 import p455w0rd.danknull.inventory.slot.SlotDankNull;
 import p455w0rd.danknull.inventory.slot.SlotHotbar;
+import p455w0rd.danknull.network.PacketSyncDankNull;
 import p455w0rd.danknull.util.DankNullUtils;
 
 /**
@@ -13,16 +16,19 @@ import p455w0rd.danknull.util.DankNullUtils;
  */
 public class ContainerDankNull extends Container {
 
+	private final PlayerSlot playerSlot;
 	private final EntityPlayer player;
-	InventoryDankNull inventoryDankNull;
 
-	public ContainerDankNull(final EntityPlayer player, final InventoryDankNull inv) {
+	public ContainerDankNull(final EntityPlayer player, final PlayerSlot slot) {
+		playerSlot = slot;
 		this.player = player;
-		inventoryDankNull = inv;
 		final InventoryPlayer playerInv = player.inventory;
-		final ItemStack dankNull = inv.getDankNull();
+		final ItemStack dankNull = playerInv.getStackInSlot(slot.getSlotIndex());
 		int lockedSlot = -1;
-		final int numRows = DankNullUtils.getTier(dankNull).getNumRows();
+		int numRows = DankNullUtils.getMeta(dankNull) + 1;
+		if (DankNullUtils.isCreativeDankNull(dankNull)) {
+			numRows--;
+		}
 		for (int i = 0; i < playerInv.getSizeInventory(); i++) {
 			final ItemStack currStack = playerInv.getStackInSlot(i);
 			if (!currStack.isEmpty() && currStack == dankNull) {
@@ -30,125 +36,240 @@ public class ContainerDankNull extends Container {
 			}
 		}
 		for (int i = 0; i < 9; i++) {
-			addSlotToContainer(new SlotHotbar(player.inventory, i, i * 20 + 9 + i, 90 + numRows - 1 + numRows * 20 + 6, lockedSlot == i));
+			addSlotToContainer(new SlotHotbar(playerInv, i, i * 20 + 9 + i, 90 + numRows - 1 + numRows * 20 + 6, lockedSlot == i));
 
 		}
 		for (int i = 0; i < 3; i++) {
 			for (int j = 0; j < 9; j++) {
-				addSlotToContainer(new Slot(player.inventory, j + i * 9 + 9, j * 20 + 9 + j, 149 + numRows - 1 + i - (6 - numRows) * 20 + i * 20));
+				addSlotToContainer(new Slot(playerInv, j + i * 9 + 9, j * 20 + 9 + j, 149 + numRows - 1 + i - (6 - numRows) * 20 + i * 20));
 			}
 		}
 		for (int i = 0; i < numRows; i++) {
 			for (int j = 0; j < 9; j++) {
-				addSlotToContainer(new SlotDankNull(inventoryDankNull, j + i * 9, j * 20 + 9 + j, 19 + i + i * 20));
+				addSlotToContainer(new SlotDankNull(playerSlot, player, j + i * 9, j * 20 + 9 + j, 19 + i + i * 20));
 			}
 		}
+		/*if (tile.getWorld() != null) {
+			tile.markDirty();
+			final IBlockState s = tile.getWorld().getBlockState(tile.getPos());
+			tile.getWorld().notifyBlockUpdate(tile.getPos(), s, s, 3);
+		}*/
+	}
+
+	public PlayerSlot getPlayerSlot() {
+		return playerSlot;
+	}
+
+	public ItemStack getDankNullInPlayerSlot() {
+		return player.inventory.getStackInSlot(playerSlot.getSlotIndex());
 	}
 
 	@Override
 	public boolean canInteractWith(final EntityPlayer playerIn) {
-		return inventoryDankNull.isValid();
+		return DankNullUtils.getNewDankNullInventory(getDankNullInPlayerSlot()).isValid();
 	}
 
-	public ItemStack getDankNull() {
-		return getDankNullInventory().getDankNull();
-	}
-
-	public InventoryDankNull getDankNullInventory() {
-		return inventoryDankNull;
-	}
-
-	public void setDankNullInventory(final InventoryDankNull inv) {
-		inventoryDankNull = inv;
-	}
-
-	public boolean addStack(final ItemStack stack) {
+	public boolean addStack(final InventoryDankNull inventory, final ItemStack stack) {
 		boolean ret = false;
 		if (DankNullUtils.isDankNull(stack)) {
 			return false;
 		}
-		if (DankNullUtils.isFiltered(getDankNullInventory(), stack)) {
-			ret = DankNullUtils.addFilteredStackToDankNull(getDankNullInventory(), stack);
+		if (DankNullUtils.isFiltered(inventory, stack)) {
+			ret = DankNullUtils.addFilteredStackToDankNull(inventory, stack);
 		}
 		else {
-			if (ret = DankNullUtils.addFilteredStackToDankNull(getDankNullInventory(), stack)) {
+			if (ret = DankNullUtils.addFilteredStackToDankNull(inventory, stack)) {
 				//noop
 			}
-			else if (DankNullUtils.getNextAvailableSlot(this) >= 0) {
-				ret = DankNullUtils.addUnfiliteredStackToDankNull(this, stack);
+			else if (DankNullUtils.getNextAvailableSlot(inventory) >= 0) {
+				final int nextSlot = DankNullUtils.getNextAvailableSlot(inventory);
+				inventory.setInventorySlotContents(nextSlot, stack);
+				inventorySlots.get(36 + nextSlot).putStack(stack);
+				ret = true;
 			}
-			if (DankNullUtils.getSelectedStackIndex(getDankNullInventory()) == -1) {
-				DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
+			if (DankNullUtils.getSelectedStackIndex(inventory) == -1) {
+				DankNullUtils.setSelectedIndexApplicable(inventory);
 			}
 		}
-		DankNullUtils.reArrangeStacks(getDankNullInventory());
+		DankNullUtils.reArrangeStacks(inventory);
 		return ret;
 	}
 
+	private boolean isDankNullSlot(final Slot slot) {
+		return slot instanceof SlotDankNull;
+	}
+
+	private boolean isInHotbar(final int index) {
+		return index >= 0 && index <= 8;
+	}
+
+	private boolean isInInventory(final int index) {
+		return index >= 9 && index <= 36;
+	}
+
 	@Override
-	public ItemStack transferStackInSlot(final EntityPlayer playerIn, final int index) {
+	public void detectAndSendChanges() {
+		//I'll take this, thanks
+	}
+
+	@Override
+	public Slot getSlot(final int slotId) {
+		if (slotId < inventorySlots.size() && slotId >= 0) {
+			return inventorySlots.get(slotId);
+		}
+		return null;
+	}
+
+	@Override
+	public ItemStack slotClick(final int index, final int dragType, final ClickType clickType, final EntityPlayer player) {
+		final Slot s = getSlot(index);
+		if (s == null || index < 36 && clickType != ClickType.QUICK_MOVE || clickType == ClickType.CLONE) {
+			return super.slotClick(index, dragType, clickType, player);
+		}
+		final InventoryDankNull tmpInv = DankNullUtils.getNewDankNullInventory(getDankNullInPlayerSlot());
+		if (clickType == ClickType.QUICK_MOVE) {
+			shiftClick(tmpInv, index, player);
+			return ItemStack.EMPTY;
+		}
+		final InventoryPlayer inventoryplayer = player.inventory;
+		final ItemStack heldStack = inventoryplayer.getItemStack();
+		if (s instanceof SlotDankNull && clickType == ClickType.PICKUP) {
+			if (DankNullUtils.isDankNull(heldStack)) {
+				return ItemStack.EMPTY;
+			}
+			final ItemStack thisStack = s.getStack();
+			if (!thisStack.isEmpty() && DankNullUtils.isDankNull(thisStack)) {
+				return ItemStack.EMPTY;
+			}
+			if (!heldStack.isEmpty()) {
+				if (!(player instanceof EntityPlayerMP)) {
+					if (addStack(tmpInv, heldStack)) {
+						DankNullUtils.setSelectedIndexApplicable(tmpInv);
+						tmpInv.markDirty();
+					}
+					sync(tmpInv.getDankNull());
+				}
+				if (player instanceof EntityPlayerMP) {
+					player.inventory.setInventorySlotContents(index, ItemStack.EMPTY);
+					player.inventory.markDirty();
+				}
+				inventoryplayer.setItemStack(ItemStack.EMPTY);
+			}
+			else if (!thisStack.isEmpty()) {
+
+				final int max = thisStack.getMaxStackSize();
+				final ItemStack newStack = thisStack.copy();
+				if (thisStack.getCount() >= max) {
+					newStack.setCount(max);
+				}
+				if (dragType == 1) {
+					final int returnSize = Math.min(newStack.getCount() / 2, newStack.getCount());
+					if (tmpInv != null) {
+						if (!(player instanceof EntityPlayerMP)) {
+
+							DankNullUtils.decrDankNullStackSize(tmpInv, thisStack, returnSize);
+						}
+						//else {
+						//	returnSize = thisStack.getCount();
+						//}
+						newStack.setCount(returnSize + (newStack.getCount() % 2 == 0 ? 0 : 1));
+					}
+				}
+				else if (dragType == 0) {
+					if (tmpInv != null) {
+						if (!(player instanceof EntityPlayerMP)) {
+							DankNullUtils.decrDankNullStackSize(tmpInv, thisStack, newStack.getCount());
+						}
+						if (inventorySlots.get(index).getHasStack() && inventorySlots.get(index).getStack().getCount() <= 0) {
+							inventorySlots.get(index).putStack(ItemStack.EMPTY);
+						}
+					}
+				}
+
+				//if (!(player instanceof EntityPlayerMP)) {
+				//DankNullUtils.decrDankNullStackSize(tmpInv, thisStack, realMaxStackSize);
+				//}
+
+				inventoryplayer.setItemStack(newStack);
+				inventoryplayer.markDirty();
+				DankNullUtils.reArrangeStacks(tmpInv);
+
+				if (!(player instanceof EntityPlayerMP)) {
+					tmpInv.markDirty();
+					sync(tmpInv.getDankNull());
+				}
+
+			}
+		}
+		return ItemStack.EMPTY;
+	}
+
+	private void sync(final ItemStack dankNull) {
+		ModNetworking.getInstance().sendToServer(new PacketSyncDankNull(playerSlot, dankNull));
+	}
+
+	private ItemStack shiftClick(final InventoryDankNull inventory, final int index, final EntityPlayer player) {
 		final Slot clickSlot = inventorySlots.get(index);
 		if (clickSlot.getHasStack()) {
 			if (!isDankNullSlot(clickSlot)) {
-				if (DankNullUtils.getNextAvailableSlot(this) == -1 && DankNullUtils.isFiltered(getDankNullInventory(), clickSlot.getStack())) {
-					if (addStack(clickSlot.getStack())) {
+				if (!(player instanceof EntityPlayerMP)) {
+					if (addStack(inventory, clickSlot.getStack())) {
 						clickSlot.putStack(ItemStack.EMPTY);
-						playerIn.inventory.markDirty();
-						DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
+						DankNullUtils.setSelectedIndexApplicable(inventory);
+						inventory.markDirty();
 					}
-					else if (!moveStackWithinInventory(clickSlot.getStack(), index)) {
-						return ItemStack.EMPTY;
+					else {
+						moveStackWithinInventory(clickSlot.getStack(), index);
 					}
-					return clickSlot.getStack();
+					sync(inventory.getDankNull());
 				}
-				else {
-					if (addStack(clickSlot.getStack())) {
-						clickSlot.putStack(ItemStack.EMPTY);
-						playerIn.inventory.markDirty();
-						DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
-					}
-					else if (!moveStackWithinInventory(clickSlot.getStack(), index)) {
-						return ItemStack.EMPTY;
-					}
-					return clickSlot.getStack();
+				if (player instanceof EntityPlayerMP) {
+					player.inventory.setInventorySlotContents(index, ItemStack.EMPTY);
+					player.inventory.markDirty();
 				}
+				return ItemStack.EMPTY;
 			}
 			else {
 				final ItemStack newStack = clickSlot.getStack().copy();
 				final int realMaxStackSize = newStack.getMaxStackSize();
 				final int currentStackSize = newStack.getCount();
-				if (currentStackSize > realMaxStackSize && !DankNullUtils.isCreativeDankNull(getDankNull())) {
-					newStack.setCount(realMaxStackSize);
-					if (moveStackToInventory(newStack)) {
-						DankNullUtils.decrDankNullStackSize(getDankNullInventory(), clickSlot.getStack(), realMaxStackSize);
+				if (!DankNullUtils.isCreativeDankNull(inventory.getDankNull())) {
+					if (currentStackSize > realMaxStackSize) {
+						newStack.setCount(realMaxStackSize);
+					}
+					if (moveStackToInventory(newStack) && !(player instanceof EntityPlayerMP)) {
+						DankNullUtils.decrDankNullStackSize(inventory, clickSlot.getStack(), realMaxStackSize);
+					}
+					if (player instanceof EntityPlayerMP) {
+						player.inventory.setInventorySlotContents(index, newStack);
+						player.inventory.markDirty();
 					}
 				}
 				else {
-					newStack.setCount(DankNullUtils.isCreativeDankNull(getDankNull()) ? newStack.getMaxStackSize() : currentStackSize);
-					if (moveStackToInventory(newStack)) {
-						DankNullUtils.decrDankNullStackSize(getDankNullInventory(), clickSlot.getStack(), currentStackSize);
-						if (!DankNullUtils.isCreativeDankNullLocked(getDankNull())) {
+					newStack.setCount(DankNullUtils.isCreativeDankNull(inventory.getDankNull()) ? newStack.getMaxStackSize() : currentStackSize);
+					if (moveStackToInventory(newStack) && !(player instanceof EntityPlayerMP)) {
+						DankNullUtils.decrDankNullStackSize(inventory, clickSlot.getStack(), currentStackSize);
+						if (DankNullUtils.isCreativeDankNull(inventory.getDankNull()) && !DankNullUtils.isCreativeDankNullLocked(inventory.getDankNull())) {
 							clickSlot.putStack(ItemStack.EMPTY);
 						}
 					}
-					DankNullUtils.reArrangeStacks(getDankNullInventory());
+
+					if (player instanceof EntityPlayerMP) {
+						player.inventory.setInventorySlotContents(index, newStack);
+						player.inventory.markDirty();
+					}
+					DankNullUtils.reArrangeStacks(inventory);
+					inventory.markDirty();
+					sync(inventory.getDankNull());
 				}
 			}
 		}
-
 		return ItemStack.EMPTY;
 	}
 
 	@Override
-	public void detectAndSendChanges() {
-		if (player instanceof EntityPlayerMP) {
-			((EntityPlayerMP) player).isChangingQuantityOnly = false;
-		}
-		super.detectAndSendChanges();
-	}
-
-	private boolean isDankNullSlot(final Slot slot) {
-		return slot instanceof SlotDankNull;
+	public ItemStack transferStackInSlot(final EntityPlayer playerIn, final int index) {
+		return ItemStack.EMPTY;
 	}
 
 	private boolean moveStackWithinInventory(final ItemStack itemStackIn, final int index) {
@@ -181,16 +302,8 @@ public class ContainerDankNull extends Container {
 		return false;
 	}
 
-	private boolean isInHotbar(final int index) {
-		return index >= 0 && index <= 8;
-	}
-
-	private boolean isInInventory(final int index) {
-		return index >= 9 && index <= 36;
-	}
-
-	protected boolean moveStackToInventory(final ItemStack itemStackIn) {
-		for (int i = 0; i <= 36; i++) {
+	private boolean moveStackToInventory(final ItemStack itemStackIn) {
+		for (int i = 0; i < 36; i++) {
 			final Slot possiblyOpenSlot = inventorySlots.get(i);
 			if (!possiblyOpenSlot.getHasStack()) {
 				possiblyOpenSlot.putStack(itemStackIn);
@@ -198,73 +311,6 @@ public class ContainerDankNull extends Container {
 			}
 		}
 		return false;
-	}
-
-	@Override
-	public ItemStack slotClick(final int index, final int dragType, final ClickType clickTypeIn, final EntityPlayer player) {
-		final InventoryPlayer inventoryplayer = player.inventory;
-		final ItemStack heldStack = inventoryplayer.getItemStack();
-		if (index < 0) {
-			return super.slotClick(index, dragType, clickTypeIn, player);
-		}
-		final Slot s = inventorySlots.get(index);
-		if (s.getStack() == inventoryDankNull.getDankNull()) {
-			return ItemStack.EMPTY;
-		}
-		if (isDankNullSlot(s)) {
-			if (DankNullUtils.isDankNull(heldStack)) {
-				return ItemStack.EMPTY;
-			}
-			final ItemStack thisStack = s.getStack();
-			if (!thisStack.isEmpty() && DankNullUtils.isDankNull(thisStack)) {
-				return ItemStack.EMPTY;
-			}
-			if (!heldStack.isEmpty()) {
-				if (addStack(heldStack)) {
-					inventoryplayer.setItemStack(ItemStack.EMPTY);
-					return heldStack;
-				}
-				else {
-					if (DankNullUtils.isCreativeDankNull(getDankNull())) {
-						return heldStack;
-					}
-					if (thisStack.getCount() <= thisStack.getMaxStackSize()) {
-						inventoryplayer.setItemStack(thisStack);
-						s.putStack(heldStack);
-					}
-					return ItemStack.EMPTY;
-				}
-			}
-			else {
-				if (!thisStack.isEmpty() && clickTypeIn == ClickType.PICKUP) {
-					final int max = thisStack.getMaxStackSize();
-					final ItemStack newStack = thisStack.copy();
-					if (thisStack.getCount() >= max) {
-						newStack.setCount(max);
-					}
-					if (dragType == 1) {
-						final int returnSize = Math.min(newStack.getCount() / 2, newStack.getCount());
-						if (getDankNullInventory() != null) {
-							DankNullUtils.decrDankNullStackSize(getDankNullInventory(), thisStack, newStack.getCount() - returnSize);
-							newStack.setCount(returnSize + (newStack.getCount() % 2 == 0 ? 0 : 1));
-						}
-					}
-					else if (dragType == 0) {
-						if (getDankNullInventory() != null) {
-							DankNullUtils.decrDankNullStackSize(getDankNullInventory(), thisStack, newStack.getCount());
-							if (inventorySlots.get(index).getHasStack() && inventorySlots.get(index).getStack().getCount() <= 0) {
-								inventorySlots.get(index).putStack(ItemStack.EMPTY);
-							}
-						}
-					}
-					inventoryplayer.setItemStack(newStack);
-					DankNullUtils.reArrangeStacks(getDankNullInventory());
-					return ItemStack.EMPTY;
-				}
-			}
-		}
-		super.slotClick(index, dragType, clickTypeIn, player);
-		return ItemStack.EMPTY;
 	}
 
 }

--- a/src/main/java/p455w0rd/danknull/container/ContainerDankNull_old.java
+++ b/src/main/java/p455w0rd/danknull/container/ContainerDankNull_old.java
@@ -1,0 +1,469 @@
+package p455w0rd.danknull.container;
+
+import java.util.List;
+
+import net.minecraft.entity.player.*;
+import net.minecraft.inventory.*;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import p455w0rd.danknull.init.ModNetworking;
+import p455w0rd.danknull.inventory.InventoryDankNull;
+import p455w0rd.danknull.inventory.slot.*;
+import p455w0rd.danknull.network.PacketRequestInitialUpdate;
+import p455w0rd.danknull.network.PacketSyncDankNull;
+import p455w0rd.danknull.util.DankNullUtils;
+
+/**
+ * @author p455w0rd
+ */
+public class ContainerDankNull_old extends Container {
+
+	private final EntityPlayer player;
+	InventoryDankNull inventoryDankNull;
+	boolean dirty = false;
+
+	public ContainerDankNull_old(final EntityPlayer player, final InventoryDankNull inv) {
+		this.player = player;
+		inventoryDankNull = inv;
+		final InventoryPlayer playerInv = player.inventory;
+		final ItemStack dankNull = inv.getDankNull();
+		int lockedSlot = -1;
+		final int numRows = DankNullUtils.getTier(dankNull).getNumRows();
+		for (int i = 0; i < playerInv.getSizeInventory(); i++) {
+			final ItemStack currStack = playerInv.getStackInSlot(i);
+			if (!currStack.isEmpty() && currStack == dankNull) {
+				lockedSlot = i;
+			}
+		}
+		for (int i = 0; i < 9; i++) {
+			addSlotToContainer(new SlotHotbar(player.inventory, i, i * 20 + 9 + i, 90 + numRows - 1 + numRows * 20 + 6, lockedSlot == i));
+
+		}
+		for (int i = 0; i < 3; i++) {
+			for (int j = 0; j < 9; j++) {
+				addSlotToContainer(new Slot(player.inventory, j + i * 9 + 9, j * 20 + 9 + j, 149 + numRows - 1 + i - (6 - numRows) * 20 + i * 20));
+			}
+		}
+		for (int i = 0; i < numRows; i++) {
+			for (int j = 0; j < 9; j++) {
+				//addSlotToContainer(new SlotDankNull(inventoryDankNull, j + i * 9, j * 20 + 9 + j, 19 + i + i * 20));
+			}
+		}
+		if (!(player instanceof EntityPlayerMP)) {
+			ModNetworking.getInstance().sendToServer(new PacketRequestInitialUpdate());
+		}
+	}
+
+	public EntityPlayer getPlayer() {
+		return player;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void setAll(final List<ItemStack> list) {
+		super.setAll(list);
+		/*for (int i = 0; i < 36; ++i) {
+			getSlot(i).putStack(list.get(i));
+		}
+		for (int i = 36; i < list.size(); ++i) {
+			final ItemStack stack = getDankNullInventory().getStackInSlot(i - 36);
+			final int realSize = getDankNullInventory().getSizeForSlot(i - 36);
+			if (stack.getCount() != realSize) {
+				stack.setCount(realSize);
+			}
+			inventoryItemStacks.set(i, stack.copy());
+			getSlot(i).putStack(stack);
+		}*/
+	}
+
+	@Override
+	public boolean canInteractWith(final EntityPlayer playerIn) {
+		return inventoryDankNull.isValid();
+	}
+
+	public ItemStack getDankNull() {
+		return getDankNullInventory().getDankNull();
+	}
+
+	public InventoryDankNull getDankNullInventory() {
+		return inventoryDankNull;
+	}
+
+	public void setDankNullInventory(final InventoryDankNull inv) {
+		inventoryDankNull = inv;
+	}
+
+	public boolean addStack(final ItemStack stack) {
+		boolean ret = false;
+		if (DankNullUtils.isDankNull(stack)) {
+			return false;
+		}
+		if (DankNullUtils.isFiltered(getDankNullInventory(), stack)) {
+			ret = DankNullUtils.addFilteredStackToDankNull(getDankNullInventory(), stack);
+		}
+		else {
+			if (ret = DankNullUtils.addFilteredStackToDankNull(getDankNullInventory(), stack)) {
+				//noop
+			}
+			else if (DankNullUtils.getNextAvailableSlot(getDankNullInventory()) >= 0) {
+				final int nextSlot = DankNullUtils.getNextAvailableSlot(getDankNullInventory());
+				getDankNullInventory().setInventorySlotContents(nextSlot, stack);
+				inventorySlots.get(36 + nextSlot).putStack(stack);
+				ret = true;
+			}
+			if (DankNullUtils.getSelectedStackIndex(getDankNullInventory()) == -1) {
+				DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
+			}
+		}
+		DankNullUtils.reArrangeStacks(getDankNullInventory());
+		return ret;
+	}
+
+	@Override
+	public ItemStack transferStackInSlot(final EntityPlayer playerIn, final int index) {
+		return ItemStack.EMPTY;
+	}
+
+	private ItemStack shiftClick(final int index, final EntityPlayer player) {
+		final Slot clickSlot = inventorySlots.get(index);
+		if (clickSlot.getHasStack()) {
+			if (!isDankNullSlot(clickSlot)) {
+				if (!(player instanceof EntityPlayerMP)) {
+					if (addStack(clickSlot.getStack())) {
+						clickSlot.putStack(ItemStack.EMPTY);
+						DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
+						getDankNullInventory().markDirty();
+					}
+					else {
+						moveStackWithinInventory(clickSlot.getStack(), index);
+					}
+					sync();
+				}
+				if (player instanceof EntityPlayerMP) {
+					player.inventory.setInventorySlotContents(index, ItemStack.EMPTY);
+					player.inventory.markDirty();
+				}
+				return ItemStack.EMPTY;
+			}
+			else {
+				final ItemStack newStack = clickSlot.getStack().copy();
+				final int realMaxStackSize = newStack.getMaxStackSize();
+				final int currentStackSize = newStack.getCount();
+				if (!DankNullUtils.isCreativeDankNull(getDankNull()) && currentStackSize > realMaxStackSize) {
+					newStack.setCount(realMaxStackSize);
+					if (moveStackToInventory(newStack) && !(player instanceof EntityPlayerMP)) {
+						DankNullUtils.decrDankNullStackSize(getDankNullInventory(), clickSlot.getStack(), realMaxStackSize);
+						sync();
+					}
+					if (player instanceof EntityPlayerMP) {
+						player.inventory.setInventorySlotContents(index, newStack);
+						player.inventory.markDirty();
+						getDankNullInventory().markDirty();
+					}
+				}
+				else {
+					newStack.setCount(DankNullUtils.isCreativeDankNull(getDankNull()) ? newStack.getMaxStackSize() : currentStackSize);
+					//if (!(player instanceof EntityPlayerMP)) {
+					if (moveStackToInventory(newStack) && !(player instanceof EntityPlayerMP)) {
+						DankNullUtils.decrDankNullStackSize(getDankNullInventory(), clickSlot.getStack(), currentStackSize);
+						if (DankNullUtils.isCreativeDankNull(getDankNull()) && !DankNullUtils.isCreativeDankNullLocked(getDankNull())) {
+							clickSlot.putStack(ItemStack.EMPTY);
+						}
+					}
+					if (!(player instanceof EntityPlayerMP)) {
+						sync();
+					}
+					if (player instanceof EntityPlayerMP) {
+						player.inventory.setInventorySlotContents(index, newStack);
+						player.inventory.markDirty();
+					}
+					DankNullUtils.reArrangeStacks(getDankNullInventory());
+				}
+			}
+		}
+		return ItemStack.EMPTY;
+	}
+
+	/*@Override
+	public ItemStack transferStackInSlot(final EntityPlayer playerIn, final int index) {
+		final Slot clickSlot = inventorySlots.get(index);
+		if (clickSlot.getHasStack()) {
+			if (!isDankNullSlot(clickSlot)) {
+				if (DankNullUtils.getNextAvailableSlot(this) == -1 && DankNullUtils.isFiltered(getDankNullInventory(), clickSlot.getStack())) {
+					if (addStack(clickSlot.getStack())) {
+						clickSlot.putStack(ItemStack.EMPTY);
+						playerIn.inventory.markDirty();
+						DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
+					}
+					else if (!moveStackWithinInventory(clickSlot.getStack(), index)) {
+						return ItemStack.EMPTY;
+					}
+					sync();
+					return clickSlot.getStack();
+				}
+				else {
+					if (addStack(clickSlot.getStack())) {
+						clickSlot.putStack(ItemStack.EMPTY);
+						playerIn.inventory.markDirty();
+						DankNullUtils.setSelectedIndexApplicable(getDankNullInventory());
+					}
+					else if (!moveStackWithinInventory(clickSlot.getStack(), index)) {
+						return ItemStack.EMPTY;
+					}
+					sync();
+					return clickSlot.getStack();
+				}
+			}
+			else {
+				final ItemStack newStack = clickSlot.getStack().copy();
+				final int realMaxStackSize = newStack.getMaxStackSize();
+				final int currentStackSize = newStack.getCount();
+				if (currentStackSize > realMaxStackSize && !DankNullUtils.isCreativeDankNull(getDankNull())) {
+					newStack.setCount(realMaxStackSize);
+					if (moveStackToInventory(newStack)) {
+						DankNullUtils.decrDankNullStackSize(getDankNullInventory(), clickSlot.getStack(), realMaxStackSize);
+					}
+				}
+				else {
+					newStack.setCount(DankNullUtils.isCreativeDankNull(getDankNull()) ? newStack.getMaxStackSize() : currentStackSize);
+					if (moveStackToInventory(newStack)) {
+						DankNullUtils.decrDankNullStackSize(getDankNullInventory(), clickSlot.getStack(), currentStackSize);
+						if (!DankNullUtils.isCreativeDankNullLocked(getDankNull())) {
+							clickSlot.putStack(ItemStack.EMPTY);
+						}
+					}
+					DankNullUtils.reArrangeStacks(getDankNullInventory());
+				}
+			}
+		}
+		sync();
+		return ItemStack.EMPTY;
+	}*/
+
+	@Override
+	public void detectAndSendChanges() {
+		// nop
+	}
+
+	private boolean isDankNullSlot(final Slot slot) {
+		return slot instanceof SlotDankNull;
+	}
+
+	private boolean moveStackWithinInventory(final ItemStack itemStackIn, final int index) {
+		if (isInHotbar(index)) {
+			if (mergeItemStack(itemStackIn, 9, 37, false)) {
+				return true;
+			}
+			for (int i = 9; i <= 36; i++) {
+				final Slot possiblyOpenSlot = inventorySlots.get(i);
+				if (!possiblyOpenSlot.getHasStack()) {
+					possiblyOpenSlot.putStack(itemStackIn);
+					inventorySlots.get(index).putStack(ItemStack.EMPTY);
+					return true;
+				}
+			}
+		}
+		else if (isInInventory(index)) {
+			if (mergeItemStack(itemStackIn, 0, 9, false)) {
+				return true;
+			}
+			for (int i = 0; i <= 8; i++) {
+				final Slot possiblyOpenSlot = inventorySlots.get(i);
+				if (!possiblyOpenSlot.getHasStack()) {
+					possiblyOpenSlot.putStack(itemStackIn);
+					inventorySlots.get(index).putStack(ItemStack.EMPTY);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private boolean isInHotbar(final int index) {
+		return index >= 0 && index <= 8;
+	}
+
+	private boolean isInInventory(final int index) {
+		return index >= 9 && index <= 36;
+	}
+
+	protected boolean moveStackToInventory(final ItemStack itemStackIn) {
+		for (int i = 0; i <= 36; i++) {
+			final Slot possiblyOpenSlot = inventorySlots.get(i);
+			if (!possiblyOpenSlot.getHasStack()) {
+				possiblyOpenSlot.putStack(itemStackIn);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/*@Override
+	public ItemStack slotClick(final int index, final int dragType, final ClickType clickTypeIn, final EntityPlayer player) {
+		final InventoryPlayer inventoryplayer = player.inventory;
+		final ItemStack heldStack = inventoryplayer.getItemStack();
+		if (index < 0) {
+			return super.slotClick(index, dragType, clickTypeIn, player);
+		}
+		final Slot s = inventorySlots.get(index);
+		if (s.getStack() == inventoryDankNull.getDankNull()) {
+			return ItemStack.EMPTY;
+		}
+		if (isDankNullSlot(s)) {
+			if (DankNullUtils.isDankNull(heldStack)) {
+				return ItemStack.EMPTY;
+			}
+			final ItemStack thisStack = s.getStack();
+			if (!thisStack.isEmpty() && DankNullUtils.isDankNull(thisStack)) {
+				return ItemStack.EMPTY;
+			}
+			if (!heldStack.isEmpty()) {
+				if (addStack(heldStack)) {
+					inventoryplayer.setItemStack(ItemStack.EMPTY);
+					return heldStack;
+				}
+				else {
+					if (DankNullUtils.isCreativeDankNull(getDankNull())) {
+						return heldStack;
+					}
+					if (thisStack.getCount() <= thisStack.getMaxStackSize()) {
+						inventoryplayer.setItemStack(thisStack);
+						s.putStack(heldStack);
+					}
+					sync();
+					return ItemStack.EMPTY;
+				}
+			}
+			else {
+				if (!thisStack.isEmpty() && clickTypeIn == ClickType.PICKUP) {
+					final int max = thisStack.getMaxStackSize();
+					final ItemStack newStack = thisStack.copy();
+					if (thisStack.getCount() >= max) {
+						newStack.setCount(max);
+					}
+					if (dragType == 1) {
+						final int returnSize = Math.min(newStack.getCount() / 2, newStack.getCount());
+						if (getDankNullInventory() != null) {
+							DankNullUtils.decrDankNullStackSize(getDankNullInventory(), thisStack, newStack.getCount() - returnSize);
+							newStack.setCount(returnSize + (newStack.getCount() % 2 == 0 ? 0 : 1));
+						}
+					}
+					else if (dragType == 0) {
+						if (getDankNullInventory() != null) {
+							DankNullUtils.decrDankNullStackSize(getDankNullInventory(), thisStack, newStack.getCount());
+							if (inventorySlots.get(index).getHasStack() && inventorySlots.get(index).getStack().getCount() <= 0) {
+								inventorySlots.get(index).putStack(ItemStack.EMPTY);
+							}
+						}
+					}
+					inventoryplayer.setItemStack(newStack);
+					inventoryplayer.markDirty();
+					if (!(player instanceof EntityPlayerMP)) {
+						DankNullUtils.reArrangeStacks(getDankNullInventory());
+						getDankNullInventory().markDirty();
+						sync();
+					}
+					return ItemStack.EMPTY;
+				}
+			}
+		}
+		super.slotClick(index, dragType, clickTypeIn, player);
+		return ItemStack.EMPTY;
+	}*/
+
+	@Override
+	public Slot getSlot(final int slotId) {
+		if (slotId < inventorySlots.size() && slotId >= 0) {
+			return inventorySlots.get(slotId);
+		}
+		return null;
+	}
+
+	@Override
+	public ItemStack slotClick(final int index, final int dragType, final ClickType clickType, final EntityPlayer player) {
+		final Slot s = getSlot(index);
+		if (index < 36 && clickType != ClickType.QUICK_MOVE || clickType == ClickType.CLONE) {
+			return super.slotClick(index, dragType, clickType, player);
+		}
+		if (clickType == ClickType.QUICK_MOVE) {
+			shiftClick(index, player);
+			return ItemStack.EMPTY;
+		}
+		final InventoryDankNull tmpInv = DankNullUtils.getNewDankNullInventory(getDankNull());
+		final InventoryPlayer inventoryplayer = player.inventory;
+		final ItemStack heldStack = inventoryplayer.getItemStack();
+		if (s instanceof SlotDankNullDock && clickType == ClickType.PICKUP) {
+			if (DankNullUtils.isDankNull(heldStack)) {
+				return ItemStack.EMPTY;
+			}
+			final ItemStack thisStack = s.getStack();
+			if (!thisStack.isEmpty() && DankNullUtils.isDankNull(thisStack)) {
+				return ItemStack.EMPTY;
+			}
+			if (!heldStack.isEmpty()) {
+				if (!(player instanceof EntityPlayerMP)) {
+					if (addStack(heldStack)) {
+						DankNullUtils.setSelectedIndexApplicable(tmpInv);
+						tmpInv.markDirty();
+					}
+					sync();
+				}
+				if (player instanceof EntityPlayerMP) {
+					player.inventory.setInventorySlotContents(index, ItemStack.EMPTY);
+					player.inventory.markDirty();
+				}
+				inventoryplayer.setItemStack(ItemStack.EMPTY);
+			}
+			else if (!thisStack.isEmpty()) {
+
+				final int max = thisStack.getMaxStackSize();
+				final ItemStack newStack = thisStack.copy();
+				if (thisStack.getCount() >= max) {
+					newStack.setCount(max);
+				}
+				if (dragType == 1) {
+					int returnSize = Math.min(newStack.getCount() / 2, newStack.getCount());
+					if (tmpInv != null) {
+						if (!(player instanceof EntityPlayerMP)) {
+
+							DankNullUtils.decrDankNullStackSize(tmpInv, thisStack, returnSize);
+						}
+						else {
+							returnSize = thisStack.getCount();
+						}
+						newStack.setCount(returnSize + (newStack.getCount() % 2 == 0 ? 0 : 1));
+					}
+				}
+				else if (dragType == 0) {
+					if (tmpInv != null) {
+						if (!(player instanceof EntityPlayerMP)) {
+							DankNullUtils.decrDankNullStackSize(tmpInv, thisStack, newStack.getCount());
+						}
+						if (inventorySlots.get(index).getHasStack() && inventorySlots.get(index).getStack().getCount() <= 0) {
+							inventorySlots.get(index).putStack(ItemStack.EMPTY);
+						}
+					}
+				}
+
+				//if (!(player instanceof EntityPlayerMP)) {
+				//DankNullUtils.decrDankNullStackSize(tmpInv, thisStack, realMaxStackSize);
+				//}
+				inventoryplayer.setItemStack(newStack);
+				inventoryplayer.markDirty();
+				if (!(player instanceof EntityPlayerMP)) {
+					DankNullUtils.reArrangeStacks(tmpInv);
+					tmpInv.markDirty();
+					sync();
+				}
+
+			}
+		}
+		return ItemStack.EMPTY;
+	}
+
+	public void sync() {
+		ModNetworking.getInstance().sendToServer(new PacketSyncDankNull(getDankNullInventory().getPlayerSlotIndex(), getDankNull()));
+	}
+
+}

--- a/src/main/java/p455w0rd/danknull/init/ModEvents.java
+++ b/src/main/java/p455w0rd/danknull/init/ModEvents.java
@@ -133,29 +133,33 @@ public class ModEvents {
 	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
 	public static void onKeyInput(final KeyInputEvent event) {
-		if (ModKeyBindings.getToggleHUDKeyBind().isPressed()) {
-			DankNullUtils.toggleHUD();
-		}
-		final EntityPlayer player = EasyMappings.player();
+		if (ModKeyBindings.isAnyModKeybindPressed()) {
+			if (ModKeyBindings.getToggleHUDKeyBind().isPressed()) {
+				DankNullUtils.toggleHUD();
+			}
+			final EntityPlayer player = EasyMappings.player();
+			if (!DankNullUtils.isDankNull(player.getHeldItemMainhand())) {
+				return;
+			}
+			final InventoryDankNull inventory = DankNullUtils.getInventoryFromHeld(player);
+			if (inventory == null) {
+				return;
+			}
 
-		final InventoryDankNull inventory = DankNullUtils.getInventoryFromHeld(player);
-		if (inventory == null) {
-			return;
-		}
-
-		if (ModKeyBindings.getOpenDankNullKeyBind().isPressed()) {
-			ModNetworking.getInstance().sendToServer(new PacketOpenDankGui());
-		}
-		final int currentIndex = DankNullUtils.getSelectedStackIndex(inventory);
-		final int totalSize = DankNullUtils.getItemCount(inventory);
-		if (currentIndex == -1 || totalSize <= 1) {
-			return;
-		}
-		if (ModKeyBindings.getNextItemKeyBind().isPressed()) {
-			DankNullUtils.setNextSelectedStack(inventory, player);
-		}
-		else if (ModKeyBindings.getPreviousItemKeyBind().isPressed()) {
-			DankNullUtils.setPreviousSelectedStack(inventory, player);
+			if (ModKeyBindings.getOpenDankNullKeyBind().isPressed()) {
+				ModNetworking.getInstance().sendToServer(new PacketOpenDankGui());
+			}
+			final int currentIndex = DankNullUtils.getSelectedStackIndex(inventory);
+			final int totalSize = DankNullUtils.getItemCount(inventory);
+			if (currentIndex == -1 || totalSize <= 1) {
+				return;
+			}
+			if (ModKeyBindings.getNextItemKeyBind().isPressed()) {
+				DankNullUtils.setNextSelectedStack(inventory, player);
+			}
+			else if (ModKeyBindings.getPreviousItemKeyBind().isPressed()) {
+				DankNullUtils.setPreviousSelectedStack(inventory, player);
+			}
 		}
 	}
 
@@ -227,13 +231,14 @@ public class ModEvents {
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public static void onMouseEvent(final MouseEvent event) {
 		final EntityPlayer player = EasyMappings.player();
-		final InventoryDankNull inventory = DankNullUtils.getInventoryFromHeld(player);
-		if (inventory == null) {
-			return;
-		}
+
 		final Minecraft mc = Minecraft.getMinecraft();
 		final World world = mc.world;
 		if (event.isButtonstate() && event.getButton() == 2 && event.getDwheel() == 0) {
+			final InventoryDankNull inventory = DankNullUtils.getInventoryFromHeld(player);
+			if (inventory == null) {
+				return;
+			}
 			final RayTraceResult target = mc.objectMouseOver;
 			if (target.typeOfHit == RayTraceResult.Type.BLOCK) {
 				final IBlockState state = world.getBlockState(target.getBlockPos());
@@ -249,7 +254,11 @@ public class ModEvents {
 				}
 			}
 		}
-		if (event.getDwheel() == 0) {
+		if (ModKeyBindings.isAnyModKeybindPressed() && event.getDwheel() == 0) {
+			final InventoryDankNull inventory = DankNullUtils.getInventoryFromHeld(player);
+			if (inventory == null) {
+				return;
+			}
 			final int currentIndex = DankNullUtils.getSelectedStackIndex(inventory);
 			final int totalSize = DankNullUtils.getItemCount(inventory);
 			if (currentIndex == -1 || totalSize <= 1) {
@@ -264,7 +273,12 @@ public class ModEvents {
 				event.setCanceled(true);
 			}
 		}
-		else if (player.isSneaking()) {
+		else if (event.getDwheel() != 0 && player.isSneaking()) {
+			// i do this multiple times to avoid constantly firing DankNullUtils#getInventoryFromHeld any time the mouse is used
+			final InventoryDankNull inventory = DankNullUtils.getInventoryFromHeld(player);
+			if (inventory == null) {
+				return;
+			}
 			final int currentIndex = DankNullUtils.getSelectedStackIndex(inventory);
 			final int totalSize = DankNullUtils.getItemCount(inventory);
 			if (currentIndex == -1 || totalSize <= 1) {

--- a/src/main/java/p455w0rd/danknull/init/ModGlobals.java
+++ b/src/main/java/p455w0rd/danknull/init/ModGlobals.java
@@ -12,7 +12,7 @@ public class ModGlobals {
 
 	public static final String MODID_PWLIB = "p455w0rdslib";
 	public static final String MODID = "danknull";
-	public static final String VERSION = "1.5.74";
+	public static final String VERSION = "1.5.76";
 	public static final String NAME = "/dank/null";
 	public static final String SERVER_PROXY = "p455w0rd.danknull.proxy.CommonProxy";
 	public static final String CLIENT_PROXY = "p455w0rd.danknull.proxy.ClientProxy";

--- a/src/main/java/p455w0rd/danknull/init/ModGuiHandler.java
+++ b/src/main/java/p455w0rd/danknull/init/ModGuiHandler.java
@@ -1,7 +1,8 @@
 package p455w0rd.danknull.init;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.Container;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -12,7 +13,6 @@ import p455w0rd.danknull.blocks.tiles.TileDankNullDock;
 import p455w0rd.danknull.client.gui.GuiDankNull;
 import p455w0rd.danknull.container.ContainerDankNull;
 import p455w0rd.danknull.container.ContainerDankNullDock;
-import p455w0rd.danknull.inventory.InventoryDankNull;
 import p455w0rd.danknull.inventory.PlayerSlot;
 import p455w0rd.danknull.util.DankNullUtils;
 
@@ -21,6 +21,8 @@ import p455w0rd.danknull.util.DankNullUtils;
  *
  */
 public class ModGuiHandler implements IGuiHandler {
+
+	//private static PlayerSlot PLAYER_SLOT;
 
 	public static void init() {
 		ModLogger.info("Registering GUI Handler");
@@ -35,8 +37,7 @@ public class ModGuiHandler implements IGuiHandler {
 			if (dankNull == null) {
 				return null;
 			}
-			final InventoryDankNull inventory = new InventoryDankNull(dankNull, player);
-			return new ContainerDankNull(player, inventory);
+			return new ContainerDankNull(player, dankNull);
 		case DANKNULL_TE:
 			final TileEntity te = world.getTileEntity(new BlockPos(x, y, z));
 			if (te instanceof TileDankNullDock) {
@@ -53,34 +54,38 @@ public class ModGuiHandler implements IGuiHandler {
 
 	@Override
 	public Object getClientGuiElement(final int id, final EntityPlayer player, final World world, final int x, final int y, final int z) {
-		final Container c = (Container) getServerGuiElement(id, player, world, x, y, z);
-		if (c != null) {
-			switch (GUIType.VALUES[id]) {
-			case DANKNULL_TE:
-				final TileEntity te = world.getTileEntity(new BlockPos(x, y, z));
-				if (te instanceof TileDankNullDock) {
-					final TileDankNullDock dankDock = (TileDankNullDock) te;
-					if (!dankDock.getDankNull().isEmpty()) {
-						final InventoryDankNull inventory = DankNullUtils.getNewDankNullInventory(dankDock.getDankNull());
-						return new GuiDankNull(c, inventory, player);
-					}
+		//final Container c = (Container) getServerGuiElement(id, player, world, x, y, z);
+		//if (c != null) {
+		switch (GUIType.VALUES[id]) {
+		case DANKNULL_TE:
+			final TileEntity te = world.getTileEntity(new BlockPos(x, y, z));
+			if (te instanceof TileDankNullDock) {
+				final TileDankNullDock dankDock = (TileDankNullDock) te;
+				if (!dankDock.getDankNull().isEmpty()) {
+					return new GuiDankNull(new ContainerDankNullDock(player, dankDock), DankNullUtils.getTier(dankDock.getDankNull()), player);
 				}
-			case DANKNULL:
-				final PlayerSlot dankNull = DankNullUtils.getDankNullSlot(player);
-				if (dankNull == null) {
-					return null;
-				}
-				final InventoryDankNull inventory = new InventoryDankNull(dankNull, player);
-				return new GuiDankNull(c, inventory, player);
-			default:
-				break;
 			}
+		case DANKNULL:
+			final PlayerSlot dankNull = DankNullUtils.getDankNullSlot(player);
+			if (dankNull == null) {
+				return null;
+			}
+			return new GuiDankNull(new ContainerDankNull(player, dankNull), player);
+		default:
+			break;
 		}
+		//}
 		return null;
 	}
 
-	public static void launchGui(final GUIType type, final EntityPlayer player, final World world, final BlockPos pos) {
+	public static void launchGui(final GUIType type, final EntityPlayer player, final World world, final BlockPos pos, @Nullable final PlayerSlot playerSlot) {
 		if (!world.isRemote) {
+			/*if (playerSlot == null) {
+				PLAYER_SLOT = null;
+			}
+			else {
+				PLAYER_SLOT = playerSlot;
+			}*/
 			player.openGui(DankNull.INSTANCE, type.ordinal(), world, pos.getX(), pos.getY(), pos.getZ());
 		}
 	}

--- a/src/main/java/p455w0rd/danknull/init/ModKeyBindings.java
+++ b/src/main/java/p455w0rd/danknull/init/ModKeyBindings.java
@@ -24,6 +24,13 @@ public class ModKeyBindings {
 		ClientRegistry.registerKeyBinding(getToggleHUDKeyBind());
 	}
 
+	public static boolean isAnyModKeybindPressed() {
+		return getNextItemKeyBind().isPressed() || //@formatter:off
+				getPreviousItemKeyBind().isPressed() ||
+				getOpenDankNullKeyBind().isPressed() ||
+				getToggleHUDKeyBind().isPressed();//@formatter:on
+	}
+
 	public static KeyBinding getNextItemKeyBind() {
 		if (nextItem == null) {
 			nextItem = new KeyBinding("key.next_item.desc", Keyboard.CHAR_NONE, CATEGORY);

--- a/src/main/java/p455w0rd/danknull/init/ModNetworking.java
+++ b/src/main/java/p455w0rd/danknull/init/ModNetworking.java
@@ -33,7 +33,8 @@ public class ModNetworking {
 		getInstance().registerMessage(PacketEmptyDock.Handler.class, PacketEmptyDock.class, nextID(), Side.CLIENT);
 		getInstance().registerMessage(PacketSetDankNullInDock.Handler.class, PacketSetDankNullInDock.class, nextID(), Side.CLIENT);
 		getInstance().registerMessage(PacketSyncDankNullDock.Handler.class, PacketSyncDankNullDock.class, nextID(), Side.SERVER);
-		getInstance().registerMessage(PacketOpenDankGui.Handler.class, PacketOpenDankGui.class, nextID(), Side.SERVER);
+		//getInstance().registerMessage(PacketOpenDankGui.Handler.class, PacketOpenDankGui.class, nextID(), Side.SERVER);
+		getInstance().registerMessage(PacketRequestInitialUpdate.Handler.class, PacketRequestInitialUpdate.class, nextID(), Side.SERVER);
 		//getInstance().registerMessage(PacketMouseWheel.Handler.class, PacketMouseWheel.class, nextID(), Side.SERVER);
 	}
 }

--- a/src/main/java/p455w0rd/danknull/integration/TOP.java
+++ b/src/main/java/p455w0rd/danknull/integration/TOP.java
@@ -115,11 +115,11 @@ public class TOP {
 						final ItemStack selectedStack = DankNullUtils.getSelectedStack(dankDock.getDankNull());
 						if (!selectedStack.isEmpty()) {
 							final ItemStack tmpStack = selectedStack.copy();
-							String countText = "";
+							/*String countText = "";
 							if (selectedStack.getCount() >= 100000) {
 								tmpStack.setCount(1);
 								countText = ", " + TextUtils.translate("dn.count.desc") + ": " + (DankNullUtils.isCreativeDankNull(dockedDankNull) ? TextUtils.translate("dn.infinite.desc") : "" + selectedStack.getCount());
-							}
+							}*/
 							topTip.horizontal(new LayoutStyle().alignment(ElementAlignment.ALIGN_TOPLEFT).borderColor(0xFFFF0000).spacing(-1)).item(tmpStack);
 							//topTip.text(" " + TextUtils.translate("dn.selected.desc") + "" + countText);
 							topTip.text(TextUtils.translate("dn.extract_mode.desc") + ": " + DankNullUtils.getExtractionModeForStack(dockedDankNull, selectedStack).getTooltip());

--- a/src/main/java/p455w0rd/danknull/integration/waila/WAILADankNullDockProvider.java
+++ b/src/main/java/p455w0rd/danknull/integration/waila/WAILADankNullDockProvider.java
@@ -12,7 +12,6 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import p455w0rd.danknull.blocks.tiles.TileDankNullDock;
 import p455w0rd.danknull.init.ModBlocks;
-import p455w0rd.danknull.init.ModConfig.Options;
 import p455w0rd.danknull.init.ModGlobals;
 import p455w0rd.danknull.integration.WAILA;
 import p455w0rd.danknull.util.DankNullUtils;
@@ -45,8 +44,8 @@ public class WAILADankNullDockProvider implements IWailaDataProvider {
 	@Override
 	public List<String> getWailaBody(final ItemStack itemStack, final List<String> currenttip, final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
 		final TileDankNullDock dankDock = (TileDankNullDock) accessor.getTileEntity();
-		final String dankNull = "/d" + (Options.callItDevNull ? "ev" : "ank") + "/null";
-		final String msg = TextUtils.translate("dn.right_click_with.desc") + (dankDock.getDankNull().isEmpty() ? " " + dankNull : " " + TextUtils.translate("dn.empty_hand_open.desc"));
+		//final String dankNull = "/d" + (Options.callItDevNull ? "ev" : "ank") + "/null";
+		//final String msg = TextUtils.translate("dn.right_click_with.desc") + (dankDock.getDankNull().isEmpty() ? " " + dankNull : " " + TextUtils.translate("dn.empty_hand_open.desc"));
 		//final InventoryDankNull dankDockInventory = dankDock.getInventory();
 		if (!dankDock.getDankNull().isEmpty()) {
 			final ItemStack dockedDankNull = dankDock.getDankNull();

--- a/src/main/java/p455w0rd/danknull/inventory/InventoryDankNull.java
+++ b/src/main/java/p455w0rd/danknull/inventory/InventoryDankNull.java
@@ -218,6 +218,8 @@ public class InventoryDankNull implements IInventory {
 		return dankNullSlot.getSlotIndex();
 	}
 
+	public int getPlayerSlotCategoryIndex() { return dankNullSlot.getCatIndex(); }
+
 	public NBTTagCompound getDNTag() {
 		final ItemStack dn = getDankNull();
 		if (!dn.hasTagCompound()) {

--- a/src/main/java/p455w0rd/danknull/inventory/slot/SlotDankNull.java
+++ b/src/main/java/p455w0rd/danknull/inventory/slot/SlotDankNull.java
@@ -5,7 +5,9 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import p455w0rd.danknull.inventory.InventoryDankNull;
+import p455w0rd.danknull.inventory.PlayerSlot;
 import p455w0rd.danknull.items.ItemDankNull;
+import p455w0rd.danknull.util.DankNullUtils;
 
 /**
  * @author p455w0rd
@@ -13,14 +15,8 @@ import p455w0rd.danknull.items.ItemDankNull;
  */
 public class SlotDankNull extends Slot {
 
-	//private Container myContainer = null;
-	//protected String backgroundName = null;
-	//protected ResourceLocation backgroundLocation = null;
-	//protected Object backgroundMap;
-	//public int slotNumber;
-
-	public SlotDankNull(final InventoryDankNull inv, final int idx, final int x, final int y) {
-		super(inv, idx, x, y);
+	public SlotDankNull(final PlayerSlot slot, final EntityPlayer player, final int idx, final int x, final int y) {
+		super(DankNullUtils.getNewDankNullInventory(slot, player), idx, x, y);
 	}
 
 	@Override
@@ -28,48 +24,23 @@ public class SlotDankNull extends Slot {
 		return !(itemStackIn.getItem() instanceof ItemDankNull);
 	}
 
-	/*
-	@Override
-	@SideOnly(Side.CLIENT)
-	public ResourceLocation getBackgroundLocation() {
-		return backgroundLocation == null ? TextureMap.LOCATION_BLOCKS_TEXTURE : backgroundLocation;
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void setBackgroundLocation(final ResourceLocation texture) {
-		backgroundLocation = texture;
-	}
-	
-	@Override
-	public void setBackgroundName(final String name) {
-		backgroundName = name;
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public TextureAtlasSprite getBackgroundSprite() {
-		final String name = getSlotTexture();
-		return name == null ? null : getBackgroundMap().getAtlasSprite(name);
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	protected TextureMap getBackgroundMap() {
-		if (backgroundMap == null) {
-			backgroundMap = Minecraft.getMinecraft().getTextureMapBlocks();
-		}
-		return (TextureMap) backgroundMap;
-	}
-	*/
 	@Override
 	public boolean getHasStack() {
 		return !getStack().isEmpty();
 	}
 
 	@Override
-	public void putStack(final ItemStack stack) {
+	public ItemStack getStack() {
+		return DankNullUtils.getStackInDankNullSlotWithSize(((InventoryDankNull) inventory).getDankNull(), getSlotIndex());
+	}
+
+	@Override
+	public void putStack(ItemStack stack) {
+		if (!stack.isEmpty() && stack.getCount() <= 0) {
+			stack = ItemStack.EMPTY;
+		}
 		inventory.setInventorySlotContents(getSlotIndex(), stack);
+		inventory.markDirty();
 		onSlotChanged();
 	}
 
@@ -83,13 +54,6 @@ public class SlotDankNull extends Slot {
 		return getSlotStackLimit();
 	}
 
-	/*
-	@Override
-	@SideOnly(Side.CLIENT)
-	public String getSlotTexture() {
-		return backgroundName;
-	}
-	*/
 	@Override
 	public ItemStack decrStackSize(final int amount) {
 		return inventory.decrStackSize(getSlotIndex(), amount);
@@ -112,14 +76,5 @@ public class SlotDankNull extends Slot {
 	public int getY() {
 		return yPos;
 	}
-	/*
-	public Container getContainer() {
-		return myContainer;
-	}
 
-	public SlotDankNull setContainer(final Container myContainer) {
-		this.myContainer = myContainer;
-		return this;
-	}
-	*/
 }

--- a/src/main/java/p455w0rd/danknull/inventory/slot/SlotDankNullDock.java
+++ b/src/main/java/p455w0rd/danknull/inventory/slot/SlotDankNullDock.java
@@ -50,15 +50,6 @@ public class SlotDankNullDock extends Slot {
 	public void putStack(final ItemStack stack) {
 		final InventoryDankNull tmpInv = DankNullUtils.getNewDankNullInventory(getDankNull());
 		tmpInv.setInventorySlotContents(getSlotIndex(), stack);
-		//tmpInv.markDirty();
-		/*
-		if (DankNullUtils.isFiltered(getDankNull(), stack)) {
-			DankNullUtils.addFilteredStackToDankNull(getDankNull(), stack);
-		}
-		else {
-			DankNullUtils.addUnfiliteredStackToDankNull(DankNullUtils.getNewDankNullInventory(getDankNull()), stack);
-		}
-		*/
 		onSlotChanged();
 	}
 

--- a/src/main/java/p455w0rd/danknull/items/ItemBlockDankNullDock.java
+++ b/src/main/java/p455w0rd/danknull/items/ItemBlockDankNullDock.java
@@ -15,7 +15,6 @@ import p455w0rd.danknull.init.ModConfig.Options;
 import p455w0rd.danknull.integration.PwLib;
 import p455w0rd.danknull.util.DankNullUtils;
 import p455w0rdslib.api.client.*;
-import p455w0rdslib.api.client.shader.IBlockLightEmitter;
 import p455w0rdslib.integration.Albedo;
 import p455w0rdslib.util.TextUtils;
 
@@ -23,8 +22,7 @@ import p455w0rdslib.util.TextUtils;
  * @author p455w0rd
  *
  */
-@SuppressWarnings("deprecation")
-public class ItemBlockDankNullDock extends ItemBlock implements IModelHolder, IBlockLightEmitter {
+public class ItemBlockDankNullDock extends ItemBlock implements IModelHolder {
 
 	ItemLayerWrapper wrappedModel;
 
@@ -96,7 +94,7 @@ public class ItemBlockDankNullDock extends ItemBlock implements IModelHolder, IB
 	/*private int brightness = 0;
 	private boolean brightnessDir = false;
 	private int step = 0;
-	
+
 	@Override
 	public void emitLight(final List<Light> lights, final Entity e) {
 		if (!Options.enabledColoredLightShaderSupport) {

--- a/src/main/java/p455w0rd/danknull/items/ItemDankNull.java
+++ b/src/main/java/p455w0rd/danknull/items/ItemDankNull.java
@@ -37,6 +37,7 @@ import p455w0rd.danknull.init.ModGuiHandler.GUIType;
 import p455w0rd.danknull.integration.PwLib;
 import p455w0rd.danknull.inventory.InventoryDankNull;
 import p455w0rd.danknull.inventory.PlayerSlot;
+import p455w0rd.danknull.inventory.PlayerSlot.EnumInvCategory;
 import p455w0rd.danknull.util.DankNullUtils;
 import p455w0rd.danknull.util.DankNullUtils.ItemPlacementMode;
 import p455w0rdslib.api.client.*;
@@ -148,7 +149,7 @@ public class ItemDankNull extends Item implements IModelHolder/*, IBlockLightEmi
 			ItemNBTUtils.setString(stack, NBT.UUID, UUID.randomUUID().toString());
 		}
 		if (player.isSneaking() && getBlockUnderPlayer(player) != Blocks.AIR && !world.isRemote) {
-			ModGuiHandler.launchGui(GUIType.DANKNULL, player, world, player.getPosition());
+			ModGuiHandler.launchGui(GUIType.DANKNULL, player, world, player.getPosition(), new PlayerSlot(player.inventory.currentItem, EnumInvCategory.MAIN));
 			return new ActionResult<>(EnumActionResult.FAIL, stack);
 		}
 		return new ActionResult<>(EnumActionResult.FAIL, stack);
@@ -209,14 +210,15 @@ public class ItemDankNull extends Item implements IModelHolder/*, IBlockLightEmi
 			return EnumActionResult.SUCCESS;
 		}
 		final ItemStack stack = player.getHeldItem(hand);
-		final InventoryDankNull inventory = new InventoryDankNull(new PlayerSlot(player.inventory.currentItem, MAIN), player);
+		final PlayerSlot playerSlot = new PlayerSlot(player.inventory.currentItem, MAIN);
+		final InventoryDankNull inventory = new InventoryDankNull(playerSlot, player);
 
 		final ItemStack selectedStack = DankNullUtils.getSelectedStack(inventory);
 		final Block selectedBlock = Block.getBlockFromItem(selectedStack.getItem());
 		final boolean isSelectedStackABlock = selectedBlock != null && selectedBlock != Blocks.AIR;
 		final Block blockUnderPlayer = getBlockUnderPlayer(player).getBlock();
 		if (player.isSneaking() && blockUnderPlayer != Blocks.AIR && isSelectedStackABlock && blockUnderPlayer != selectedBlock) {
-			ModGuiHandler.launchGui(GUIType.DANKNULL, player, world, player.getPosition());
+			ModGuiHandler.launchGui(GUIType.DANKNULL, player, world, player.getPosition(), playerSlot);
 			return EnumActionResult.SUCCESS;
 		}
 		final ItemPlacementMode placementMode = DankNullUtils.getPlacementModeForStack(stack, selectedStack);
@@ -401,7 +403,7 @@ public class ItemDankNull extends Item implements IModelHolder/*, IBlockLightEmi
 	private static boolean brightnessDir = false;
 	private static int step = 0;
 	private static boolean initLight = false;
-	
+
 	@Override
 	public void emitLight(final List<Light> lights, final Entity e) {
 		if (e == null || !Options.enabledColoredLightShaderSupport) {
@@ -452,7 +454,7 @@ public class ItemDankNull extends Item implements IModelHolder/*, IBlockLightEmi
 					}
 				}
 			}
-	
+
 			final Vec3i c = RenderUtils.hexToRGB(DankNullUtils.getTier(lightStack).getHexColor(false));
 			lights.add(Light.builder().pos(e).color(c.getX(), c.getY(), c.getZ(), (float) (brightness * 0.001)).radius(2.5f).intensity(5).build());
 		}

--- a/src/main/java/p455w0rd/danknull/network/PacketConfigSync.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketConfigSync.java
@@ -1,20 +1,13 @@
 package p455w0rd.danknull.network;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import com.google.common.base.Throwables;
-
 import io.netty.buffer.ByteBuf;
 import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
-import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
-import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.common.network.simpleimpl.*;
 
 /**
  * @author p455w0rd
@@ -27,42 +20,42 @@ public class PacketConfigSync implements IMessage {
 	public PacketConfigSync() {
 	}
 
-	public PacketConfigSync(Map<String, Object> valuesIn) {
+	public PacketConfigSync(final Map<String, Object> valuesIn) {
 		values = valuesIn;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void fromBytes(ByteBuf buf) {
-		short len = buf.readShort();
-		byte[] compressedBody = new byte[len];
+	public void fromBytes(final ByteBuf buf) {
+		final short len = buf.readShort();
+		final byte[] compressedBody = new byte[len];
 
 		for (short i = 0; i < len; i++) {
 			compressedBody[i] = buf.readByte();
 		}
 
 		try {
-			ObjectInputStream obj = new ObjectInputStream(new GZIPInputStream(new ByteArrayInputStream(compressedBody)));
+			final ObjectInputStream obj = new ObjectInputStream(new GZIPInputStream(new ByteArrayInputStream(compressedBody)));
 			values = (Map<String, Object>) obj.readObject();
 			obj.close();
 		}
-		catch (Exception e) {
-			Throwables.propagate(e);
+		catch (final Exception e) {
+			throw new RuntimeException(e);
 		}
 	}
 
 	@Override
-	public void toBytes(ByteBuf buf) {
-		ByteArrayOutputStream obj = new ByteArrayOutputStream();
+	public void toBytes(final ByteBuf buf) {
+		final ByteArrayOutputStream obj = new ByteArrayOutputStream();
 
 		try {
-			GZIPOutputStream gzip = new GZIPOutputStream(obj);
-			ObjectOutputStream objStream = new ObjectOutputStream(gzip);
+			final GZIPOutputStream gzip = new GZIPOutputStream(obj);
+			final ObjectOutputStream objStream = new ObjectOutputStream(gzip);
 			objStream.writeObject(values);
 			objStream.close();
 		}
-		catch (Exception e) {
-			Throwables.propagate(e);
+		catch (final Exception e) {
+			throw new RuntimeException(e);
 		}
 		buf.writeShort(obj.size());
 		buf.writeBytes(obj.toByteArray());
@@ -75,7 +68,7 @@ public class PacketConfigSync implements IMessage {
 			return null;
 		}
 
-		private void handle(PacketConfigSync message, MessageContext ctx) {
+		private void handle(final PacketConfigSync message, final MessageContext ctx) {
 			if (ctx.getClientHandler() != null) {
 				//Options.TEMP_REGULATOR_RADIUS = (Integer) message.values.get("TempRegulatorBlockRadius");
 			}

--- a/src/main/java/p455w0rd/danknull/network/PacketMouseWheel.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketMouseWheel.java
@@ -48,7 +48,7 @@ public class PacketMouseWheel implements IMessage {
 			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> {
 				final EntityPlayer player = ctx.getServerHandler().player;
 				if (player.openContainer instanceof ContainerDankNull || player.openContainer instanceof ContainerDankNullDock) {
-					final ItemStack dankNull = player.openContainer instanceof ContainerDankNull ? ((ContainerDankNull) player.openContainer).getDankNull() : ((ContainerDankNullDock) player.openContainer).getDankNull();
+					//final ItemStack dankNull = player.openContainer instanceof ContainerDankNull ? ((ContainerDankNull) player.openContainer).getDankNullInPlayerSlot() : ((ContainerDankNullDock) player.openContainer).getDankNull();
 					final Slot s = player.openContainer.inventorySlots.get(36 + message.values[1]);
 					if (s instanceof SlotDankNull || s instanceof SlotDankNullDock) {
 						if (message.values[0] == 0) { //add

--- a/src/main/java/p455w0rd/danknull/network/PacketOpenDankGui.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketOpenDankGui.java
@@ -1,11 +1,8 @@
 package p455w0rd.danknull.network;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.*;
-import p455w0rd.danknull.init.ModGuiHandler;
-import p455w0rd.danknull.init.ModGuiHandler.GUIType;
 
 /**
  * @author p455w0rd
@@ -25,8 +22,8 @@ public class PacketOpenDankGui implements IMessage {
 		@Override
 		public IMessage onMessage(final PacketOpenDankGui message, final MessageContext ctx) {
 			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> {
-				final EntityPlayer player = ctx.getServerHandler().player;
-				ModGuiHandler.launchGui(GUIType.DANKNULL, player, player.getEntityWorld(), player.getPosition());
+				//final EntityPlayer player = ctx.getServerHandler().player;
+				//ModGuiHandler.launchGui(GUIType.DANKNULL, player, player.getEntityWorld(), player.getPosition());
 			});
 			return null;
 		}

--- a/src/main/java/p455w0rd/danknull/network/PacketRequestInitialUpdate.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketRequestInitialUpdate.java
@@ -1,0 +1,39 @@
+package p455w0rd.danknull.network;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.inventory.Container;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.*;
+import p455w0rd.danknull.container.ContainerDankNull;
+
+/**
+ * @author p455w0rd
+ *
+ */
+public class PacketRequestInitialUpdate implements IMessage {
+
+	public PacketRequestInitialUpdate() {
+	}
+
+	@Override
+	public void fromBytes(final ByteBuf buf) {
+	}
+
+	@Override
+	public void toBytes(final ByteBuf buf) {
+	}
+
+	public static class Handler implements IMessageHandler<PacketRequestInitialUpdate, IMessage> {
+		@Override
+		public IMessage onMessage(final PacketRequestInitialUpdate message, final MessageContext ctx) {
+			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> {
+				final Container c = ctx.getServerHandler().player.openContainer;
+				if (c instanceof ContainerDankNull) {
+					//((ContainerDankNull) c).sync();
+				}
+			});
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/p455w0rd/danknull/network/PacketSetDankNullInDock.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketSetDankNullInDock.java
@@ -12,8 +12,6 @@ import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.*;
 import p455w0rd.danknull.DankNull;
 import p455w0rd.danknull.blocks.tiles.TileDankNullDock;
-import p455w0rd.danknull.inventory.InventoryDankNull;
-import p455w0rd.danknull.util.DankNullUtils;
 
 /**
  * @author p455w0rd
@@ -57,7 +55,7 @@ public class PacketSetDankNullInDock implements IMessage {
 				final TileEntity te = world.getTileEntity(message.pos);
 				if (te != null && te instanceof TileDankNullDock) {
 					final TileDankNullDock dankDock = (TileDankNullDock) te;
-					final InventoryDankNull inv = DankNullUtils.getNewDankNullInventory(message.dankNull);
+					//final InventoryDankNull inv = DankNullUtils.getNewDankNullInventory(message.dankNull);
 					//dankDock.removeDankNull();
 					dankDock.setDankNull(message.dankNull);
 					//world.updateComparatorOutputLevel(message.pos, te.getBlockType());

--- a/src/main/java/p455w0rd/danknull/network/PacketSyncDankNull.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketSyncDankNull.java
@@ -7,11 +7,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
-import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
-import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
-import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.common.network.simpleimpl.*;
 import net.minecraftforge.fml.relauncher.Side;
+import p455w0rd.danknull.DankNull;
 import p455w0rd.danknull.inventory.InventoryDankNull;
+import p455w0rd.danknull.inventory.PlayerSlot;
 import p455w0rd.danknull.util.DankNullUtils;
 import p455w0rdslib.util.EasyMappings;
 
@@ -27,7 +27,7 @@ public class PacketSyncDankNull implements IMessage {
 	private boolean isLocked;
 
 	@Override
-	public void fromBytes(ByteBuf buf) {
+	public void fromBytes(final ByteBuf buf) {
 		slot = buf.readInt();
 		dankNull = ByteBufUtils.readItemStack(buf);
 		stackSizes = new int[buf.readInt()];
@@ -38,10 +38,10 @@ public class PacketSyncDankNull implements IMessage {
 	}
 
 	@Override
-	public void toBytes(ByteBuf buf) {
+	public void toBytes(final ByteBuf buf) {
 		buf.writeInt(slot);
 		ByteBufUtils.writeItemStack(buf, dankNull);
-		InventoryDankNull inv = DankNullUtils.getNewDankNullInventory(dankNull);
+		final InventoryDankNull inv = DankNullUtils.getNewDankNullInventory(dankNull);
 		buf.writeInt(inv.getSizeInventory());
 		for (int i = 0; i < inv.getSizeInventory(); i++) {
 			buf.writeInt(DankNullUtils.getNewDankNullInventory(dankNull).getSizeForSlot(i));
@@ -52,11 +52,15 @@ public class PacketSyncDankNull implements IMessage {
 	public PacketSyncDankNull() {
 	}
 
-	public PacketSyncDankNull(Pair<Integer, ItemStack> syncedDankNull) {
+	public PacketSyncDankNull(final PlayerSlot slot, final ItemStack dankNull) {
+		this(slot.getSlotIndex(), dankNull);
+	}
+
+	public PacketSyncDankNull(final Pair<Integer, ItemStack> syncedDankNull) {
 		this(syncedDankNull.getLeft(), syncedDankNull.getRight());
 	}
 
-	public PacketSyncDankNull(int slot, ItemStack stack) {
+	public PacketSyncDankNull(final int slot, final ItemStack stack) {
 		this.slot = slot;
 		dankNull = stack;
 		isLocked = DankNullUtils.isCreativeDankNullLocked(stack);
@@ -64,7 +68,7 @@ public class PacketSyncDankNull implements IMessage {
 
 	public static class Handler implements IMessageHandler<PacketSyncDankNull, IMessage> {
 		@Override
-		public IMessage onMessage(PacketSyncDankNull message, MessageContext ctx) {
+		public IMessage onMessage(final PacketSyncDankNull message, final MessageContext ctx) {
 			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> {
 				if (ctx.side == Side.CLIENT) {
 					handleToClient(message, ctx);
@@ -76,23 +80,17 @@ public class PacketSyncDankNull implements IMessage {
 			return null;
 		}
 
-		private void handleToServer(PacketSyncDankNull message, MessageContext ctx) {
+		private void handleToServer(final PacketSyncDankNull message, final MessageContext ctx) {
 			handle(message, ctx.getServerHandler().player, ctx.side);
 		}
 
-		private void handleToClient(PacketSyncDankNull message, MessageContext ctx) {
+		private void handleToClient(final PacketSyncDankNull message, final MessageContext ctx) {
 			handle(message, EasyMappings.player(), ctx.side);
+			DankNull.PROXY.setGuiInventory(DankNullUtils.getNewDankNullInventory(message.dankNull));
 		}
 
-		private void handle(PacketSyncDankNull message, EntityPlayer player, Side side) {
-			ItemStack stack = message.dankNull;
-			/*
-			InventoryDankNull inv = DankNullUtils.getNewDankNullInventory(stack);
-			int[] sizes = message.stackSizes;
-			for (int i = 0; i < sizes.length; i++) {
-				inv.setSizeForSlot(i, sizes[i]);
-			}
-			*/
+		private void handle(final PacketSyncDankNull message, final EntityPlayer player, final Side side) {
+			final ItemStack stack = message.dankNull;
 			player.inventory.setInventorySlotContents(message.slot, stack);
 			DankNullUtils.setLocked(stack, message.isLocked);
 		}

--- a/src/main/java/p455w0rd/danknull/network/PacketSyncDankNullDock.java
+++ b/src/main/java/p455w0rd/danknull/network/PacketSyncDankNullDock.java
@@ -3,6 +3,7 @@ package p455w0rd.danknull.network;
 import javax.annotation.Nonnull;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -72,6 +73,9 @@ public class PacketSyncDankNullDock implements IMessage {
 				final TileDankNullDock dankDock = (TileDankNullDock) world.getTileEntity(message.dockPos);
 				final ItemStack dankNull = message.dankNull;
 				dankDock.setDankNull(dankNull);
+				dankDock.markDirty();
+				final IBlockState s = world.getBlockState(dankDock.getPos());
+				world.notifyBlockUpdate(dankDock.getPos(), s, s, 3);
 			}
 		}
 	}

--- a/src/main/java/p455w0rd/danknull/proxy/ClientProxy.java
+++ b/src/main/java/p455w0rd/danknull/proxy/ClientProxy.java
@@ -3,9 +3,12 @@ package p455w0rd.danknull.proxy;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.event.*;
+import p455w0rd.danknull.client.gui.GuiDankNull;
 import p455w0rd.danknull.init.*;
+import p455w0rd.danknull.inventory.InventoryDankNull;
 import p455w0rdslib.util.EasyMappings;
 
 public class ClientProxy extends CommonProxy {
@@ -51,5 +54,15 @@ public class ClientProxy extends CommonProxy {
 
 	public GuiScreen getScreen() {
 		return Minecraft.getMinecraft().currentScreen;
+	}
+
+	@Override
+	public void setGuiInventory(final InventoryDankNull inventory) {
+		final GuiScreen gui = getScreen();
+		if (gui instanceof GuiDankNull) {
+			final GuiDankNull dankGui = (GuiDankNull) gui;
+			final InventoryDankNull currentInv = dankGui.getDankNullInventory();
+			currentInv.loadInventory(inventory.saveInventory(new NBTTagCompound()));
+		}
 	}
 }

--- a/src/main/java/p455w0rd/danknull/proxy/CommonProxy.java
+++ b/src/main/java/p455w0rd/danknull/proxy/CommonProxy.java
@@ -5,6 +5,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.event.*;
 import p455w0rd.danknull.init.*;
+import p455w0rd.danknull.inventory.InventoryDankNull;
 
 public class CommonProxy {
 
@@ -38,5 +39,9 @@ public class CommonProxy {
 
 	public World getWorld(final int dimension) {
 		return FMLCommonHandler.instance().getMinecraftServerInstance().getWorld(dimension);
+	}
+
+	public void setGuiInventory(final InventoryDankNull inventory) {
+
 	}
 }

--- a/src/main/java/p455w0rd/danknull/util/DankNullUtils.java
+++ b/src/main/java/p455w0rd/danknull/util/DankNullUtils.java
@@ -35,6 +35,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.commons.lang3.tuple.Triple;
 import p455w0rd.danknull.blocks.BlockDankNullDock;
 import p455w0rd.danknull.blocks.tiles.TileDankNullDock;
 import p455w0rd.danknull.client.gui.GuiDankNull;
@@ -214,7 +215,7 @@ public class DankNullUtils {
 			final ContainerDankNullDock c = (ContainerDankNullDock) gui.inventorySlots;
 			return new PacketSyncDankNullDock(c.getTile(), c.getDankNull());
 		}
-		return new PacketSyncDankNull(Pair.of(gui.getDankNullInventory().getPlayerSlotIndex(), gui.getDankNull()));
+		return new PacketSyncDankNull(Triple.of(gui.getDankNullInventory().getPlayerSlotIndex(), gui.getDankNullInventory().getPlayerSlotCategoryIndex(), gui.getDankNull()));
 	}
 
 	public static NonNullList<ItemStack> getInventoryListArray(final InventoryDankNull inventory) {

--- a/src/main/java/p455w0rd/danknull/util/DankNullUtils.java
+++ b/src/main/java/p455w0rd/danknull/util/DankNullUtils.java
@@ -18,7 +18,6 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.entity.player.*;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
@@ -170,7 +169,7 @@ public class DankNullUtils {
 
 	public static void reArrangeStacks(final TileDankNullDock dankDock) {
 		if (isDankDock(dankDock) && !dankDock.getDankNull().isEmpty()) {
-			final InventoryDankNull tmpInv = getNewDankNullInventory(dankDock.getDankNull());
+			//final InventoryDankNull tmpInv = getNewDankNullInventory(dankDock.getDankNull());
 			reArrangeStacks(dankDock.getDankNull());
 		}
 	}
@@ -214,7 +213,8 @@ public class DankNullUtils {
 			final ContainerDankNullDock c = (ContainerDankNullDock) gui.inventorySlots;
 			return new PacketSyncDankNullDock(c.getTile(), c.getDankNull());
 		}
-		return new PacketSyncDankNull(Pair.of(gui.getDankNullInventory().getPlayerSlotIndex(), gui.getDankNull()));
+		final ContainerDankNull c = (ContainerDankNull) gui.inventorySlots;
+		return new PacketSyncDankNull(Pair.of(c.getPlayerSlot().getSlotIndex(), gui.getDankNull()));
 	}
 
 	public static NonNullList<ItemStack> getInventoryListArray(final InventoryDankNull inventory) {
@@ -557,13 +557,13 @@ public class DankNullUtils {
 		return true;
 	}
 
-	public static boolean addUnfiliteredStackToDankNull(final ContainerDankNull container, final ItemStack stack) {
+	/*public static boolean addUnfiliteredStackToDankNull(final ContainerDankNull container, final ItemStack stack) {
 		if (container.getDankNullInventory() != null && canStackBeAdded(container.getDankNullInventory(), stack)) {
 			container.inventorySlots.get(getNextAvailableSlot(container)).putStack(stack);
 			return true;
 		}
 		return false;
-	}
+	}*/
 
 	//TODO remove when these classes get merged
 	public static boolean addUnfiliteredStackToDankNull(final InventoryDankNull inventory, final ItemStack stack) {
@@ -572,19 +572,6 @@ public class DankNullUtils {
 			return true;
 		}
 		return false;
-	}
-
-	public static int getNextAvailableSlot(final ContainerDankNull container) {
-		if (isCreativeDankNull(container.getDankNull()) && isCreativeDankNullLocked(container.getDankNull())) {
-			return -1;
-		}
-		for (int i = 36; i < container.inventorySlots.size(); i++) {
-			final Slot s = container.inventorySlots.get(i);
-			if (s != null && s.getStack().isEmpty()) {
-				return i;
-			}
-		}
-		return -1;
 	}
 
 	public static int getNextAvailableSlot(final InventoryDankNull inventory) {
@@ -624,6 +611,32 @@ public class DankNullUtils {
 		}
 		return false;
 	}
+
+	/*public static boolean addFilteredStackToDankNull(final ContainerDankNull container, ItemStack filteredStack) {
+		if (container.getDankNullInventory() != null && canStackBeAdded(container.getDankNullInventory(), filteredStack)) {
+			final InventoryDankNull inventory = container.getDankNullInventory();
+			if (getIndexForStack(inventory, filteredStack) >= 0) {
+				final ItemStack currentStack = getFilteredStack(inventory, filteredStack);
+				if (!currentStack.isEmpty() && !filteredStack.isEmpty() && !ItemUtils.areItemStacksEqualIgnoreSize(currentStack, filteredStack)) {
+					filteredStack = convertToOreDictedStack(filteredStack, currentStack);
+				}
+				if (filteredStack.getCount() < Integer.MAX_VALUE) {
+					final long currentSize = currentStack.getCount();
+					final long maxDankNullStackSize = getTier(inventory).getMaxStackSize();
+					if (currentSize + filteredStack.getCount() > maxDankNullStackSize) {
+						currentStack.setCount((int) maxDankNullStackSize);
+					}
+					else {
+						currentStack.setCount((int) currentSize + filteredStack.getCount());
+					}
+					inventory.setInventorySlotContents(getIndexForStack(inventory, filteredStack), currentStack);
+					container.inventorySlots.get(36 + getIndexForStack(inventory, filteredStack)).putStack(currentStack);
+					return true;
+				}
+			}
+		}
+		return false;
+	}*/
 
 	public static boolean addFilteredStackToDankNull(final InventoryDankNull inventory, ItemStack filteredStack) {
 		if (canStackBeAdded(inventory, filteredStack)) {

--- a/src/main/java/yalter/mousetweaks/api/MouseTweaksIgnore.java
+++ b/src/main/java/yalter/mousetweaks/api/MouseTweaksIgnore.java
@@ -1,0 +1,10 @@
+package yalter.mousetweaks.api;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+		ElementType.TYPE
+})
+public @interface MouseTweaksIgnore {
+}


### PR DESCRIPTION
the sync packet was causing a duplication because it sent the slot number but not the inventory number.  If you accessed it from another inventory (such as your offhand) it would set the corresponding slot in your primary inventory.  I added the inventory type to the packet to ensure it sets the appropriate inventory slot.  