### PR TITLE
General issue fixing

### DIFF
--- a/src/main/java/p455w0rd/danknull/blocks/tiles/TileDankNullDock.java
+++ b/src/main/java/p455w0rd/danknull/blocks/tiles/TileDankNullDock.java
@@ -24,6 +24,8 @@ import p455w0rd.danknull.inventory.DankNullHandler;
 import p455w0rd.danknull.inventory.cap.CapabilityDankNull;
 import p455w0rd.danknull.items.ItemDankNull;
 
+import java.util.Objects;
+
 /**
  * @author p455w0rd
  *
@@ -206,7 +208,16 @@ public class TileDankNullDock extends TileEntity {
 		compound = super.writeToNBT(compound);
 		final ItemStack dankNull = getDankNull();
 		if (dankNullHandler != null) {
-			dankNull.setTagCompound((NBTTagCompound) CapabilityDankNull.DANK_NULL_CAPABILITY.writeNBT(dankNullHandler, null));
+			NBTTagCompound oldNBT = dankNull.getTagCompound();
+			NBTTagCompound newNBT = (NBTTagCompound) CapabilityDankNull.DANK_NULL_CAPABILITY.writeNBT(dankNullHandler, null);
+			if (Objects.nonNull(oldNBT)) {
+				if (Objects.nonNull(newNBT)) {
+					oldNBT.merge(newNBT);
+				}
+			} else {
+				oldNBT = newNBT;
+			}
+			dankNull.setTagCompound(oldNBT);
 		}
 		compound.setTag(NBT.DOCKEDSTACK, dankNull.serializeNBT());
 		return compound;

--- a/src/main/java/p455w0rd/danknull/init/ModEvents.java
+++ b/src/main/java/p455w0rd/danknull/init/ModEvents.java
@@ -173,6 +173,7 @@ public class ModEvents {
 					final Pair<EnumHand, IDankNullHandler> dankNull = getHandlerFromHeld(player);
 					if (Objects.nonNull(dankNull)) {
 						dankNull.getRight().cycleSelected(ModKeyBindings.getNextItemKeyBind().isKeyDown());
+						ModNetworking.getInstance().sendToServer(new PacketChangeMode(PacketChangeMode.ChangeType.SELECTED, dankNull.getRight().getSelected(), false, dankNull.getLeft()));
 					}
 				}
 			}

--- a/src/main/java/p455w0rd/danknull/init/ModEvents.java
+++ b/src/main/java/p455w0rd/danknull/init/ModEvents.java
@@ -1,6 +1,7 @@
 package p455w0rd.danknull.init;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.input.Keyboard;
@@ -162,11 +163,17 @@ public class ModEvents {
 				HUDRenderer.toggleHUD();
 			}
 			final EntityPlayer player = EasyMappings.player();
-			// Open GUI of first /dank/null found in player's inventory
-			if (ModKeyBindings.getOpenDankNullKeyBind().isPressed()) {
-				final List<PlayerSlot> dankNulls = ItemDankNull.getDankNullsForPlayer(player);
-				if (!dankNulls.isEmpty()) {
+			final List<PlayerSlot> dankNulls = ItemDankNull.getDankNullsForPlayer(player);
+			//Only check keybinds if player has DankNulls
+			if (!dankNulls.isEmpty()) {
+				if (ModKeyBindings.getOpenDankNullKeyBind().isPressed()) {
 					ModNetworking.getInstance().sendToServer(new PacketOpenGui(dankNulls.get(0)));
+				}
+				if (ModKeyBindings.getNextItemKeyBind().isPressed() || ModKeyBindings.getPreviousItemKeyBind().isPressed()) {
+					final Pair<EnumHand, IDankNullHandler> dankNull = getHandlerFromHeld(player);
+					if (Objects.nonNull(dankNull)) {
+						dankNull.getRight().cycleSelected(ModKeyBindings.getNextItemKeyBind().isKeyDown());
+					}
 				}
 			}
 		}

--- a/src/main/java/p455w0rd/danknull/init/ModGlobals.java
+++ b/src/main/java/p455w0rd/danknull/init/ModGlobals.java
@@ -12,7 +12,7 @@ public class ModGlobals {
 
 	public static final String MODID_PWLIB = "p455w0rdslib";
 	public static final String MODID = "danknull";
-	public static final String VERSION = "1.7.89";
+	public static final String VERSION = "1.7.90a";
 	public static final String NAME = "/dank/null";
 	public static final String SERVER_PROXY = "p455w0rd.danknull.proxy.CommonProxy";
 	public static final String CLIENT_PROXY = "p455w0rd.danknull.proxy.ClientProxy";

--- a/src/main/java/p455w0rd/danknull/init/ModKeyBindings.java
+++ b/src/main/java/p455w0rd/danknull/init/ModKeyBindings.java
@@ -25,10 +25,10 @@ public class ModKeyBindings {
 	}
 
 	public static boolean isAnyModKeybindPressed() {
-		return getNextItemKeyBind().isPressed() || //@formatter:off
-				getPreviousItemKeyBind().isPressed() ||
-				getOpenDankNullKeyBind().isPressed() ||
-				getToggleHUDKeyBind().isPressed();//@formatter:on
+		return getNextItemKeyBind().isKeyDown() || //@formatter:off
+				getPreviousItemKeyBind().isKeyDown() ||
+				getOpenDankNullKeyBind().isKeyDown() ||
+				getToggleHUDKeyBind().isKeyDown();//@formatter:on
 	}
 
 	public static KeyBinding getNextItemKeyBind() {

--- a/src/main/java/p455w0rd/danknull/inventory/cap/CapabilityDankNull.java
+++ b/src/main/java/p455w0rd/danknull/inventory/cap/CapabilityDankNull.java
@@ -89,7 +89,7 @@ public class CapabilityDankNull {
 				if (instance instanceof DankNullHandler) {
 					final DankNullHandler handler = (DankNullHandler) instance;
 					final NBTTagCompound tag = (NBTTagCompound) base;
-					if (tag.hasNoTags()) {
+					if (tag == null || tag.hasNoTags()) {
 						return;
 					}
 					if (tag.hasKey(ModGlobals.NBT.DANKNULL_INVENTORY)) {

--- a/src/main/java/p455w0rd/danknull/inventory/cap/CapabilityDankNull.java
+++ b/src/main/java/p455w0rd/danknull/inventory/cap/CapabilityDankNull.java
@@ -112,15 +112,19 @@ public class CapabilityDankNull {
 							ItemStack stack = new ItemStack(item.getCompoundTag(ModGlobals.NBT.STACK));
 							if (!stack.isEmpty()) {
 								final Map<ItemStack, Boolean> oreStacks = instance.getOres();
+								boolean foundStack = false;
 								for (final ItemStack currentStack : oreStacks.keySet()) {
 									if (ItemUtils.areItemStacksEqualIgnoreSize(currentStack, stack)) {
 										oreStacks.put(currentStack, oreDict);
+										foundStack = true;
 										break;
 									}
 								}
-								stack = stack.copy();
-								stack.setCount(1);
-								oreStacks.put(stack, oreDict);
+								if (!foundStack) {
+									stack = stack.copy();
+									stack.setCount(1);
+									oreStacks.put(stack, oreDict);
+								}
 							}
 						}
 					}
@@ -133,15 +137,19 @@ public class CapabilityDankNull {
 
 							if (!stack.isEmpty()) {
 								final Map<ItemStack, ItemExtractionMode> extractionStacks = instance.getExtractionModes();
+								boolean foundStack = false;
 								for (final ItemStack currentStack : extractionStacks.keySet()) {
 									if (ItemUtils.areItemStacksEqualIgnoreSize(currentStack, stack)) {
 										extractionStacks.put(currentStack, mode);
+										foundStack = true;
 										return;
 									}
 								}
-								stack = stack.copy();
-								stack.setCount(1);
-								extractionStacks.put(stack, mode);
+								if (!foundStack) {
+									stack = stack.copy();
+									stack.setCount(1);
+									extractionStacks.put(stack, mode);
+								}
 							}
 
 						}

--- a/src/main/java/p455w0rd/danknull/inventory/cap/DankNullCapabilityProvider.java
+++ b/src/main/java/p455w0rd/danknull/inventory/cap/DankNullCapabilityProvider.java
@@ -11,6 +11,8 @@ import p455w0rd.danknull.init.ModGlobals;
 import p455w0rd.danknull.inventory.DankNullHandler;
 import p455w0rdslib.util.CapabilityUtils;
 
+import java.util.Objects;
+
 /**
  * @author BrockWS
  */
@@ -26,13 +28,31 @@ public class DankNullCapabilityProvider implements ICapabilityProvider {
 			@Override
 			protected void onContentsChanged(final int slot) {
 				super.onContentsChanged(slot);
-				stack.setTagCompound((NBTTagCompound) CapabilityDankNull.DANK_NULL_CAPABILITY.writeNBT(this, null));
+				NBTTagCompound oldNBT = stack.getTagCompound();
+				NBTTagCompound newNBT = (NBTTagCompound) CapabilityDankNull.DANK_NULL_CAPABILITY.writeNBT(this, null);
+				if (Objects.nonNull(oldNBT)) {
+					if (Objects.nonNull(newNBT)) {
+						oldNBT.merge(newNBT);
+					}
+				} else {
+					oldNBT = newNBT;
+				}
+				stack.setTagCompound(oldNBT);
 			}
 
 			@Override
 			protected void onSettingsChanged() {
 				super.onSettingsChanged();
-				stack.setTagCompound((NBTTagCompound) CapabilityDankNull.DANK_NULL_CAPABILITY.writeNBT(this, null));
+				NBTTagCompound oldNBT = stack.getTagCompound();
+				NBTTagCompound newNBT = (NBTTagCompound) CapabilityDankNull.DANK_NULL_CAPABILITY.writeNBT(this, null);
+				if (Objects.nonNull(oldNBT)) {
+					if (Objects.nonNull(newNBT)) {
+						oldNBT.merge(newNBT);
+					}
+				} else {
+					oldNBT = newNBT;
+				}
+				stack.setTagCompound(oldNBT);
 			}
 		};
 		if (stack.hasTagCompound()) {

--- a/src/main/java/p455w0rd/danknull/items/ItemDankNull.java
+++ b/src/main/java/p455w0rd/danknull/items/ItemDankNull.java
@@ -265,7 +265,7 @@ public class ItemDankNull extends Item implements IModelHolder {
 		else if (!block.isReplaceable(world, posIn) && selectedBlock != null && !selectedBlock.isFullBlock(selectedBlock.getStateFromMeta(selectedStack.getMetadata()))) {
 			pos = pos.offset(facing);
 		}
-		if (selectedStack.getCount() > 0 && player.canPlayerEdit(posIn, facing, stack)) {
+		if (selectedStack.getCount() > 0 && player.canPlayerEdit(posIn, facing, stack) && world.isValid(posIn.offset(facing))) {
 			final int meta = selectedStack.getMetadata();
 			if (selectedBlock instanceof BlockStairs || selectedBlock instanceof BlockBanner) {
 				final IBlockState newState = selectedBlock.getStateForPlacement(world, pos, facing, hitX, hitY, hitZ, meta, player);


### PR DESCRIPTION
Fixed a few issues:
#262, #259, #241 There was an issue on readNBT, where it tried to filter out, whether the item had NBT compound tags or not. The problem lied in not check if the item had NBT at all (freshly crafted ones doesn't have NBT)

#261 Added an `world.isValid` check when you place blocks, so it doesn't place if it's outside of the border. This results in not being able to place blocks beyond 30m x/z. Another one is that if you use the mod which allows you to build above 255, if it's not overriding this function, you won't be able to place blocks.

#255 The `isPressed` can only called once per event. The `isAnyModKeyPressed` event made so that the consequent calls of isPressed returns false, event though it was pressed. With a little tweaking, I was able to use `isKeyDown` and `isPressed`, but it results in continuous press when the key is held.  The next and prev button only works, if the DankNull is selected.

#256 The oreDictionary (and the extraction check) was looping through the items and adding them to the getOres() list. Now, when it looped at the end it always added the existing ones, diregarding whether it found it or not. This caused to duplicate the entries after each world reload (and other factors, like AE2, though that was harder to replicate). Implementing a found check fixed the duplication issue